### PR TITLE
Support extracting snippet when Psalm crashes

### DIFF
--- a/src/SnippetResolver/index.ts
+++ b/src/SnippetResolver/index.ts
@@ -10,16 +10,26 @@ export class SnippetResolver {
     const results = await fetch(`${url}/results`)
       .then(async(response) => await response.json());
 
+    if (results.error !== undefined) {
+      return {
+        text: text,
+        results: null,
+        internalError: results.error
+      };
+    }
+
     return {
       text: text,
-      results: results
+      results: results,
+      internalError: null
     };
   }
 }
 
 export interface ResolvedSnippet {
   text: string;
-  results: SnippetResults;
+  results: SnippetResults|null;
+  internalError: SnippetInternalError|null;
 }
 
 export interface SnippetResults {
@@ -27,6 +37,10 @@ export interface SnippetResults {
   version: string;
   fixed_contents?: string;
   hash: string;
+}
+
+export interface SnippetInternalError {
+  message: string
 }
 
 export interface SnippetIssue {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,21 +21,33 @@ export = (app: Application) => {
     )
 
     return `I found these snippets:
-${resolvedSnippets.map(snippet => `
-<details>
-<summary>${snippet.link}</summary>
+${resolvedSnippets.map(snippet => {
+  const snippetCode = `<summary>${snippet.link}</summary>
 
 \`\`\`php
 ${snippet.text}
 \`\`\`
-\`\`\`
+`
+  let snippetOutput = ""
+  if (snippet.internalError !== null) {
+    snippetOutput = `\`\`\`
+Psalm encountered an internal error:
+
+${snippet.internalError.message}
+\`\`\``
+  }
+  else if (snippet.results !== null) {
+    snippetOutput = `\`\`\`
 Psalm output (using commit ${snippet.results.version.split('@')[1].substr(0, 7)}):
 
 ${snippet.results.results.length ? snippet.results.results.map(issue => `${issue.severity.toUpperCase()}: ${issue.type} - ${issue.line_from}:${issue.column_from} - ${issue.message}`).join('\n\n') : 'No issues!'}
-\`\`\`
-</details>
-`).join('\n')}
-`
+\`\`\``
+  }
+  return `<details>
+${snippetCode}
+${snippetOutput}
+</details>`;
+}).join('\n')} `}
   }
 
   const makeGreeting = (login: string): string => `Hey @${login}, can you reproduce the issue on https://psalm.dev ?` 

--- a/test/SnippetResolver.test.ts
+++ b/test/SnippetResolver.test.ts
@@ -84,6 +84,31 @@ describe('SnippetResolver', () => {
         version: expect.stringMatching(/dev-master/),
         fixed_contents: null,
         hash: expect.stringMatching(/^[a-f0-9]+$/)
+      },
+      internalError: null
+    })
+  })
+
+  test('returns check results of a snippet with an internal error', async () => {
+    nock('https://psalm.dev')
+      .get('/r/whateverfail/raw')
+      .reply(200, '<?php whatever();')
+
+    nock('https://psalm.dev')
+      .get('/r/whateverfail/results')
+      .reply(200, {
+        error: {
+          message: 'Fatal error whatever in Foo.php',
+          line: 387,
+          type: 'psalm_error'
+        }
+      })
+
+    const resolved = await resolver.resolve('whateverfail')
+    expect(resolved).toMatchObject({
+      results: null,
+      internalError: {
+        message: 'Fatal error whatever in Foo.php'
       }
     })
   })


### PR DESCRIPTION
psalm.dev also returns internal errors that might be
encountered, see psalm/psalm.dev@89db5c4eb5de09cf4a8011a8819bf1330928320f.