### PR TITLE
Pass detected query params to /results

### DIFF
--- a/src/Bot/index.ts
+++ b/src/Bot/index.ts
@@ -134,7 +134,7 @@ export class Bot {
 
   private async makeResponse(links: LinkEntry[]): Promise<string> {
     const resolvedSnippets = await Promise.all(
-      links.map(entry => this.resolver.resolve(entry.snippet))
+      links.map(entry => this.resolver.resolve(entry))
     )
     return this.responder.snippetResponse(resolvedSnippets)
   }

--- a/src/CommentParser/index.ts
+++ b/src/CommentParser/index.ts
@@ -2,21 +2,22 @@ export class CommentParser {
   parseComment(comment: string): LinkEntry[] {
     let matches;
     let snippets = [];
-    const regexp = /psalm\.dev\/r\/(\w+)/g;
+    const regexp = /psalm\.dev\/r\/(\w+)(\?([^\s]+))?/g;
 
     const seen: Set<string> = new Set;
 
     while ((matches = regexp.exec(comment)) !== null) {
-      if (seen.has(matches[1])) {
+      if (seen.has(matches[0])) {
         continue;
       }
 
       snippets.push({
         link: 'https://' + matches[0], 
-        snippet: matches[1]
+        snippet: matches[1],
+        params: matches[3]
       });
 
-      seen.add(matches[1]);
+      seen.add(matches[0]);
     }
 
     return snippets;
@@ -26,4 +27,5 @@ export class CommentParser {
 export interface LinkEntry {
   link: string;
   snippet: string;
+  params: string;
 }

--- a/src/SnippetResolver/index.ts
+++ b/src/SnippetResolver/index.ts
@@ -2,6 +2,7 @@ import type {Logger} from 'pino';
 import fetch from 'node-fetch';
 import {performance, PerformanceObserver} from 'perf_hooks';
 import util from 'util';
+import {LinkEntry} from '../CommentParser';
 
 export class SnippetResolver {
   log: Logger;
@@ -16,13 +17,13 @@ export class SnippetResolver {
     this.obs.observe({entryTypes: ['measure'], buffered: true})
   }
 
-  async resolve(snippetId: string): Promise<ResolvedSnippet> {
-    this.log.debug('Resolving snippet: %s', snippetId)
-    const url = `https://psalm.dev/r/${snippetId}`
+  async resolve(link: LinkEntry): Promise<ResolvedSnippet> {
+    this.log.debug('Resolving snippet: %s', link.snippet)
+    const url = `https://psalm.dev/r/${link.snippet}`;
 
-    const startMark = util.format('start resolving %s', snippetId)
-    const snippetReceivedMark = util.format('snippet received %s', snippetId)
-    const resultsReceivedMark = util.format('results received %s', snippetId)
+    const startMark = util.format('start resolving %s', link.snippet)
+    const snippetReceivedMark = util.format('snippet received %s', link.snippet)
+    const resultsReceivedMark = util.format('results received %s', link.snippet)
 
     performance.mark(startMark)
 
@@ -31,7 +32,7 @@ export class SnippetResolver {
 
     performance.mark(snippetReceivedMark)
 
-    const response = await fetch(`${url}/results`)
+    const response = await fetch(`${url}/results` + (link.params.length ? ('?' + link.params) : ''))
     let results = { error: { message: 'Bot failed to fetch results' } } as any
     const body = await response.text()
     if (body.length) {
@@ -47,17 +48,17 @@ export class SnippetResolver {
     performance.mark(resultsReceivedMark)
 
     performance.measure(
-      util.format('Fetching snippet %s', snippetId),
+      util.format('Fetching snippet %s', link.snippet),
       startMark,
       snippetReceivedMark
     )
     performance.measure(
-      util.format('Fetching results for %s', snippetId),
+      util.format('Fetching results for %s', link.snippet),
       snippetReceivedMark,
       resultsReceivedMark
     )
     performance.measure(
-      util.format('Total for %s', snippetId),
+      util.format('Total for %s', link.snippet),
       startMark,
       resultsReceivedMark
     )

--- a/test/CommentParser.test.ts
+++ b/test/CommentParser.test.ts
@@ -49,4 +49,16 @@ describe('CommentParser', () => {
       { link: 'https://psalm.dev/r/0f9f06ebd6', snippet: '0f9f06ebd6' }
     ])
   })
+
+  test('returns links with query params', () => {
+    expect(
+      parser.parseComment('see psalm.dev/r/92da00ab3c?php=7.3 - it should be resolved')
+    ).toEqual([
+      {
+        link: 'https://psalm.dev/r/92da00ab3c?php=7.3',
+        snippet: '92da00ab3c',
+        params: 'php=7.3'
+      }
+    ])
+  })
 })

--- a/test/SnippetResolver.test.ts
+++ b/test/SnippetResolver.test.ts
@@ -23,7 +23,11 @@ describe('SnippetResolver', () => {
       .get('/r/whatever/results')
       .reply(200, {})
 
-    await resolver.resolve('whatever')
+    await resolver.resolve({
+      link: 'https://psalm.dev/r/whatever',
+      snippet: 'whatever',
+      params: ''
+    })
     expect(expectedRequest.isDone()).toBeTruthy()
   })
 
@@ -41,7 +45,11 @@ describe('SnippetResolver', () => {
         hash: '37a9c929671770c6aba45e9af8072f19'
       })
 
-    await resolver.resolve('whatever')
+    await resolver.resolve({
+      link: 'https://psalm.dev/r/whatever',
+      snippet: 'whatever',
+      params: ''
+    })
     expect(expectedRequest.isDone()).toBeTruthy()
   })
 
@@ -59,7 +67,11 @@ describe('SnippetResolver', () => {
         hash: '37a9c929671770c6aba45e9af8072f19'
       })
 
-    const resolved = await resolver.resolve('whatever')
+    const resolved = await resolver.resolve({
+      link: 'https://psalm.dev/r/whatever',
+      snippet: 'whatever',
+      params: ''
+    })
 
     expect(resolved).toMatchObject({ text: '<?php whatever();' })
   })
@@ -78,7 +90,11 @@ describe('SnippetResolver', () => {
         hash: '37a9c929671770c6aba45e9af8072f19'
       })
 
-    const resolved = await resolver.resolve('whatever')
+    const resolved = await resolver.resolve({
+      link: 'https://psalm.dev/r/whatever',
+      snippet: 'whatever',
+      params: ''
+    })
     expect(resolved).toMatchObject({
       results: {
         results: [],
@@ -105,7 +121,11 @@ describe('SnippetResolver', () => {
         }
       })
 
-    const resolved = await resolver.resolve('whateverfail')
+    const resolved = await resolver.resolve({
+      link: 'https://psalm.dev/r/whateverfail',
+      snippet: 'whateverfail',
+      params: ''
+    })
     expect(resolved).toMatchObject({
       results: null,
       internalError: {
@@ -126,7 +146,11 @@ describe('SnippetResolver', () => {
       .get('/r/whateverfail/results')
       .reply(200, fatalError, { 'content-type': 'text/html; charset=UTF-8' })
 
-    const resolved = await resolver.resolve('whateverfail')
+    const resolved = await resolver.resolve({
+      link: 'https://psalm.dev/r/whateverfail',
+      snippet: 'whateverfail',
+      params: ''
+    })
     expect(resolved).toMatchObject({
       results: null,
       internalError: {
@@ -144,12 +168,34 @@ describe('SnippetResolver', () => {
       .get('/r/whateverfail/results')
       .reply(500, '')
 
-    const resolved = await resolver.resolve('whateverfail')
+    const resolved = await resolver.resolve({
+      link: 'https://psalm.dev/r/whateverfail',
+      snippet: 'whateverfail',
+      params: ''
+    })
     expect(resolved).toMatchObject({
       results: null,
       internalError: {
         message: 'Failed to parse results: (received no output)'
       }
     })
+  })
+
+  test('result includes query string', async () => {
+    nock('https://psalm.dev')
+      .get('/r/whatever/raw')
+      .reply(200, '<?php whatever();')
+
+    const expectedRequest = nock('https://psalm.dev')
+      .get('/r/whatever/results?php=7.3')
+      .reply(200, {})
+
+    await resolver.resolve({
+      link: 'https://psalm.dev/r/whatever?php=7.3',
+      snippet: 'whatever',
+      params: 'php=7.3'
+    })
+
+    expect(expectedRequest.isDone()).toBeTruthy()
   })
 })


### PR DESCRIPTION
This is required to pass params like `php=7.3`

Fixes #315

Requires psalm/psalm.dev#46 to be merged first